### PR TITLE
Fix blackbox script portability on Linux

### DIFF
--- a/scripts/search-blackbox.sh
+++ b/scripts/search-blackbox.sh
@@ -15,7 +15,7 @@ while true; do
   cp "$RANDOM_FILE" F-Droid1.apk
 
   # 4. Run your test
-  python3 blackbox-onerun.py
+  python3 src/blackbox-onerun.py
 
   # 5. Check results
   if unzip -t F-Droid1.apk >/dev/null; then
@@ -23,7 +23,7 @@ while true; do
     apkanalyzer apk summary F-Droid1.apk
     
     # Save the successful result with a unique hashed name
-    HASH=$(date +%s%N | md5 | head -c 8)
+    HASH=$(date +%s%N | md5sum | head -c 8)
     cp F-Droid1.apk "seeds/F-Droid_${HASH}.apk"
   else
     echo "ZIP BROKEN"

--- a/src/blackbox-onerun.py
+++ b/src/blackbox-onerun.py
@@ -1,6 +1,6 @@
 import os, random, sys
 
-path = "/Users/karine/Downloads/F-Droid1.apk"
+path = "F-Droid1.apk"
 i = 7401341
 j = i + 8921
 


### PR DESCRIPTION
Fixed portability issues in the blackbox fuzzing script when running the project on a clean Linux setup.

Changes made:
- Updated `search-blackbox.sh` to call `src/blackbox-onerun.py` instead of looking for `blackbox-onerun.py` in the repository root.
- Replaced `md5` with `md5sum`
- Replaced the hardcoded macOS path with the local relative path `F-Droid1.apk`.